### PR TITLE
Improve git credential sharing in devcontainer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,8 @@ ENV CONTAINER=$PD_CONTAINER_NAME
 USER $PD_USER_NAME
 
 # Set the working directory in the *container*
+RUN mkdir -p /home/$PD_USER_NAME/$PD_WORKSPACE/git-repo
+
 WORKDIR /home/$PD_USER_NAME/$PD_WORKSPACE
 
 # Set the default command

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -5,10 +5,11 @@
 	},
 	"runArgs": [
 		"--mount", "type=bind,src=${localEnv:HOME}/.gnupg,dst=/home/ubuntu/.gnupg,readonly",
-		"--mount", "type=bind,src=/run/user/1000/gnupg,dst=/run/user/1000/gnupg,readonly"
-	],	
-	"workspaceMount": "type=bind,src=${localWorkspaceFolder},target=/home/ubuntu/wksp/${localWorkspaceFolderBasename}",
-	"workspaceFolder": "/home/ubuntu/wksp/${localWorkspaceFolderBasename}",
+		"--mount", "type=bind,src=/run/user/1000/gnupg,dst=/run/user/1000/gnupg,readonly",
+		"--mount", "type=bind,src=${localEnv:HOME}/wksp/git-config,dst=/home/ubuntu/wksp/git-config,readonly"
+	],
+	"workspaceMount": "type=bind,src=${localWorkspaceFolder},target=/home/ubuntu/wksp/git-repo/${localWorkspaceFolderBasename}",
+	"workspaceFolder": "/home/ubuntu/wksp/git-repo/${localWorkspaceFolderBasename}",
 	"customizations": {
 		"vscode": {
 			"settings": {},


### PR DESCRIPTION
Add a mount of "git-repo" folder into the devcontainer, to allow `includeif` or `include` for external git config.