### PR TITLE
Update start_vnc.sh to set DISPLAY variable and adjust VNC ports

### DIFF
--- a/Dockerfile.qt6-dev-vnc
+++ b/Dockerfile.qt6-dev-vnc
@@ -108,10 +108,10 @@ USER $PD_USER_NAME
 ENV USER=$PD_USER_NAME
 ENV HOME=$PD_USER_HOME
 ENV SHELL='/bin/bash'
-ENV DISPLAY=':1'
+ENV DISPLAY=':2'
 
 # Expose the noVNC port
-EXPOSE "6901/tcp"
+EXPOSE "6902/tcp"
 
 # Set the working directory in the *container*
 WORKDIR $PD_WORKSPACE

--- a/Dockerfile.ros1-qt6-vnc
+++ b/Dockerfile.ros1-qt6-vnc
@@ -118,10 +118,10 @@ USER $PD_USER_NAME
 ENV USER=$PD_USER_NAME
 ENV HOME=$PD_USER_HOME
 ENV SHELL='/bin/bash'
-ENV DISPLAY=':1'
+ENV DISPLAY=':2'
 
 # Expose the noVNC port
-EXPOSE "6901/tcp"
+EXPOSE "6902/tcp"
 
 # Set the working directory in the *container*
 WORKDIR $PD_WORKSPACE

--- a/copy/service/start_vnc.sh
+++ b/copy/service/start_vnc.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
 # @brief: Start a VNC server and a noVNC server
-# @note: The DISPLAY environment variable must be set before running this script.
 
+DISPLAY=':2'
 VNC_SCREEN_SIZE='1920x1080'
 VNC_COLOR_DEPTH='24'
 VNC_SCREEN_DPI='96'
-VNC_PORT='5901'
-NOVNC_PORT='6901'
+VNC_PORT='5902'
+NOVNC_PORT='6902'
 
-vncserver ${DISPLAY?} -geometry $VNC_SCREEN_SIZE -depth $VNC_COLOR_DEPTH -dpi $VNC_SCREEN_DPI
+vncserver $DISPLAY -geometry $VNC_SCREEN_SIZE -depth $VNC_COLOR_DEPTH -dpi $VNC_SCREEN_DPI
 websockify --daemon --web=/usr/share/novnc/ $NOVNC_PORT localhost:$VNC_PORT
 
-echo "=== VNC server started on ${DISPLAY} with port $VNC_PORT"
+echo "=== VNC server started on $DISPLAY with port $VNC_PORT"
 echo "=== noVNC server started on port $NOVNC_PORT"
 echo "=== Remember to forward the ports to your host machine."

--- a/devcontainer.ros1-qt6-vnc
+++ b/devcontainer.ros1-qt6-vnc
@@ -5,7 +5,7 @@
 		"--mount", "type=bind,src=${localEnv:HOME}/.gnupg,dst=/home/ubuntu/.gnupg,readonly",
 		"--mount", "type=bind,src=/run/user/1000/gnupg,dst=/run/user/1000/gnupg,readonly",
 		"--mount", "type=bind,src=${localEnv:HOME}/wksp/git-config,dst=/home/ubuntu/wksp/git-config,readonly",
-		"--publish", "6901:6901/tcp",
+		"--publish", "6902:6902/tcp",
 		"--shm-size=2g",
 		"--device=/dev/input/js0"
 	],


### PR DESCRIPTION
Usually primary/physical DISPLAY will be `:0` or `:1`.
Use `:2` for the VNC/noVNC to avoid trouble.
